### PR TITLE
Make it possible to set all vue-gtag options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ Then add the following to you `gridsom.config.js` plugins array
 
 
 ```shell script
- {
-            use: 'gridsome-plugin-gtag',
-            options: {
-                id: process.env.GOOGLE_ANALYTICS_ID,
-            },
+{
+    use: 'gridsome-plugin-gtag',
+    options: {
+        config: {
+            id: process.env.GOOGLE_ANALYTICS_ID,
         },
-``` 
+    },
+},
+```
 
 
 ### Developed, Sponsored and Supported 

--- a/gridsome.client.js
+++ b/gridsome.client.js
@@ -3,7 +3,7 @@ export default function(Vue, options, {isClient, router}) {
     if (!isClient) return
 
     Vue.use(VueGtag, {
-        "config": {"id": options.id}
+        ...options
     }, router)
 
 }


### PR DESCRIPTION
Hi 👋

Would be nice to be able to set all of the available options for vue-gtag.

Would also be nice to only enable vue-gtag once in production as default. But maybe the following deserves it's own PR.

```
Vue.use(VueGtag, {
    enabled: process.env.NODE_ENV === 'production',
    ...options
}, router)
```

This would also allow users to override it.

Cheers!